### PR TITLE
LogglyTarget - Fixed breaking change introduced in loggly-csharp

### DIFF
--- a/examples/Demo/Demo.csproj
+++ b/examples/Demo/Demo.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="loggly-csharp" Version="4.6.1.45" />
-    <PackageReference Include="loggly-csharp-config" Version="4.6.1.64" />
+    <PackageReference Include="loggly-csharp" Version="4.6.1.55" />
+    <PackageReference Include="loggly-csharp-config" Version="4.6.1.55" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/NLog.Targets.Loggly/NLog.Targets.Loggly.csproj
+++ b/src/NLog.Targets.Loggly/NLog.Targets.Loggly.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="loggly-csharp" Version="4.6.1.45" />
-    <PackageReference Include="NLog" Version="4.5.0" />
+    <PackageReference Include="loggly-csharp" Version="4.6.1.55" />
+    <PackageReference Include="NLog" Version="4.5.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolves #24 by handling breaking change introduced here: https://github.com/neutmute/loggly-csharp/pull/84

Improved performance by using `Target.RenderLogEvent()` for handling NLog-Layout (reduces allocation)

Removed legacy code that was important in older versions of NLog. Fixed with NLog 4.5.4 See also https://github.com/NLog/NLog/pull/2586