### PR TITLE
LogglyTarget - Added support for Loggly config in Nlog.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ This NLog target project reads the [loggly-csharp configuration](https://github.
 
 See below for sample NLog config (loggly config not shown).
 
-	<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  throwExceptions="true">
+	<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  throwConfigExceptions="true">
 		<extensions>
 		  <add assembly="NLog.Targets.Loggly" />
 		</extensions>
 		<variable name="DefaultLayout" value="${longdate} | ${level:uppercase=true:padding=5} | ${message} | ${exception:format=type,tostring}" />
-		<variable name="AppName" value="Loggly NLog Target Demo" />
 	
 		<targets async="true">
 		  <target name="ColorConsole" xsi:type="ColoredConsole" layout="${DefaultLayout}" />
@@ -32,6 +31,20 @@ See below for sample NLog config (loggly config not shown).
 		  <logger name="*" minlevel="Info" writeTo="ColorConsole,Loggly" />
 		</rules>
 	</nlog>
+
+### Loggly EndPoint Config
+Loggly Config can be configured through the NLog Target properties:
+
+	<target name="Loggly" xsi:type="Loggly" layout="${message}" applicationName="MyApp" customerToken="your token" endpointHostname="logs-01.loggly.com" endpointPort="443" logTransport="https">
+	</target>
+
+The following settings are supported:
+
+- _CustomerToken_ - Required value, unless configured elsewhere
+- _LogTransport_ - Loggly EndPoint Protocol (Https, SyslogUdp, SyslogTcp, SyslogSecure). Default = Https
+- _EndpointHostname_ - Loggly EndPoint HostName. Default = logs-01.loggly.com
+- _EndpointPort_ - Loggly EndPoint Port Number. Default = Value matching LogTransport
+- _ApplicationName_ - Application Identifier. Default = AppDomain FriendlyName
 
 ### Tags
 

--- a/build.ps1
+++ b/build.ps1
@@ -58,13 +58,18 @@ function nugetPack{
 
 function nugetPublish{
 
-    if(Test-Path Env:\nugetapikey ){
-        _WriteOut -ForegroundColor $ColorScheme.Banner "Nuget publish..."
-        &nuget push $outputFolder\* -ApiKey "$env:nugetapikey" -source https://www.nuget.org
-    }
-    else{
-        _WriteOut -ForegroundColor Yellow "nugetapikey environment variable not detected. Skipping nuget publish"
-    }
+    if($env:APPVEYOR_PULL_REQUEST_NUMBER){
+		_WriteOut -ForegroundColor Yellow "Pull Request Build Detected. Skipping Publish"
+	}
+	else{
+		if(Test-Path Env:\nugetapikey ){
+	        _WriteOut -ForegroundColor $ColorScheme.Banner "Nuget publish..."
+		    &nuget push $outputFolder\* -ApiKey "$env:nugetapikey" -source https://www.nuget.org
+		}
+		else{
+			_WriteOut -ForegroundColor Yellow "nugetapikey environment variable not detected. Skipping nuget publish"
+		}
+	}
 }
 
 function buildSolution{

--- a/examples/Demo/App.config
+++ b/examples/Demo/App.config
@@ -16,7 +16,6 @@
       <add assembly="NLog.Targets.Loggly" />
     </extensions>
     <variable name="DefaultLayout" value="${longdate} | ${level:uppercase=true:padding=5} | ${message} | ${exception:format=type,tostring}" />
-    <variable name="AppName" value="Loggly NLog Target Demo" />
 
     <targets async="true">
       <target name="ColorConsole" xsi:type="ColoredConsole" layout="${DefaultLayout}" />

--- a/src/NLog.Targets.Loggly/LogglyTarget.cs
+++ b/src/NLog.Targets.Loggly/LogglyTarget.cs
@@ -89,19 +89,16 @@ namespace NLog.Targets
 
         protected override void InitializeTarget()
         {
-            if (string.IsNullOrWhiteSpace(LogglyConfig.Instance.ApplicationName))
+            var customerToken = CustomerToken?.Render(LogEventInfo.CreateNullEvent());
+            if (!string.IsNullOrWhiteSpace(customerToken))
             {
+                LogglyConfig.Instance.CustomerToken = customerToken;
+
                 var applicationName = ApplicationName?.Render(LogEventInfo.CreateNullEvent());
                 if (!string.IsNullOrWhiteSpace(applicationName))
                 {
                     LogglyConfig.Instance.ApplicationName = applicationName;
                 }
-            }
-
-            var customerToken = CustomerToken?.Render(LogEventInfo.CreateNullEvent());
-            if (!string.IsNullOrWhiteSpace(customerToken))
-            {
-                LogglyConfig.Instance.CustomerToken = customerToken;
             }
 
             var endPointHostName = EndpointHostname?.Render(LogEventInfo.CreateNullEvent());

--- a/src/NLog.Targets.Loggly/LogglyTarget.cs
+++ b/src/NLog.Targets.Loggly/LogglyTarget.cs
@@ -24,6 +24,7 @@ using Loggly.Config;
 using Loggly.Transports.Syslog;
 using NLog.Common;
 using NLog.Config;
+using NLog.Layouts;
 
 namespace NLog.Targets
 {
@@ -51,6 +52,31 @@ namespace NLog.Targets
         [ArrayParameter(typeof(TargetPropertyWithContext), "contextproperty")]
         public override IList<TargetPropertyWithContext> ContextProperties { get; } = new List<TargetPropertyWithContext>();
 
+        /// <summary>
+        /// 
+        /// </summary>
+        public Layout ApplicationName { get; set; } = "${appdomain:cached=true:format=\\{1\\}}";
+
+        /// <summary>
+        /// Loggly Customer Token
+        /// </summary>
+        public Layout CustomerToken { get; set; }
+
+        /// <summary>
+        /// Loggly EndPoint HostName
+        /// </summary>
+        public Layout EndpointHostname { get; set; }
+
+        /// <summary>
+        /// Loggly EndPoint Host PortNumber
+        /// </summary>
+        public Layout EndpointPort { get; set; }
+
+        /// <summary>
+        /// Loggly EndPoint Protocol (Https, SyslogSecure, SyslogUdp, SyslogTcp)
+        /// </summary>
+        public LogTransport LogTransport { get; set; }
+
         public LogglyTarget()
         {
             ClientFactory = () => new LogglyClient();
@@ -63,6 +89,38 @@ namespace NLog.Targets
 
         protected override void InitializeTarget()
         {
+            if (string.IsNullOrWhiteSpace(LogglyConfig.Instance.ApplicationName))
+            {
+                var applicationName = ApplicationName?.Render(LogEventInfo.CreateNullEvent());
+                if (!string.IsNullOrWhiteSpace(applicationName))
+                {
+                    LogglyConfig.Instance.ApplicationName = applicationName;
+                }
+            }
+
+            var customerToken = CustomerToken?.Render(LogEventInfo.CreateNullEvent());
+            if (!string.IsNullOrWhiteSpace(customerToken))
+            {
+                LogglyConfig.Instance.CustomerToken = customerToken;
+            }
+
+            var endPointHostName = EndpointHostname?.Render(LogEventInfo.CreateNullEvent());
+            if (!string.IsNullOrWhiteSpace(endPointHostName))
+            {
+                var endpointPort = EndpointPort?.Render(LogEventInfo.CreateNullEvent());
+                if (!int.TryParse(endpointPort ?? string.Empty, out var endpointPortNumber))
+                {
+                    endpointPortNumber = 0; // Let Loggly guess from LogTransport-enum
+                }
+
+                LogglyConfig.Instance.Transport = new TransportConfiguration()
+                {
+                    EndpointHostname = endPointHostName,
+                    EndpointPort = endpointPortNumber,
+                    LogTransport = LogTransport,
+                }.GetCoercedToValidConfig();
+            }
+
             base.InitializeTarget();
             _pendingTaskCount = 0;
             _client = ClientFactory.Invoke();

--- a/src/NLog.Targets.Loggly/NLog.Targets.Loggly.csproj
+++ b/src/NLog.Targets.Loggly/NLog.Targets.Loggly.csproj
@@ -10,6 +10,13 @@
     <PackageTags>NLog;Loggly</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/neutmute/nlog-targets-loggly/master/SolutionItems/NLoggly.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/neutmute/nlog-targets-loggly</PackageProjectUrl>
+    <PackageReleaseNotes>The following Loggly Config Values can be configured directly on the NLog Target:
+- CustomerToken - Required value, unless configured elsewhere
+- LogTransport - Loggly EndPoint Protocol (Https, SyslogUdp, SyslogTcp, SyslogSecure). Default = Https
+- EndpointHostname - Loggly EndPoint HostName. Default = logs-01.loggly.com
+- EndpointPort - Loggly EndPoint Port Number. Default = Value matching LogTransport
+- ApplicationName - Application Identifier. Default = AppDomain FriendlyName
+    </PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/neutmute/nlog-targets-loggly.git</RepositoryUrl>
 


### PR DESCRIPTION
The following Loggly Config Values can be configured directly on the NLog Target:
- _CustomerToken_ - Required value, unless configured elsewhere
- _LogTransport_ - Loggly EndPoint Protocol (Https, SyslogUdp, SyslogTcp, SyslogSecure). Default = Https
- _EndpointHostname_ - Loggly EndPoint HostName. Default = logs-01.loggly.com
- _EndpointPort_ - Loggly EndPoint Port Number. Default = Value matching LogTransport
- _ApplicationName_ - Application Identifier. Default = AppDomain FriendlyName